### PR TITLE
fix: AttackComponent의 CharacterCore 의존성을 ICharacterCore로 변경

### DIFF
--- a/Assets/02.Scripts/Components/AttackComponent.cs
+++ b/Assets/02.Scripts/Components/AttackComponent.cs
@@ -6,7 +6,7 @@ using ProjectD_and_R.Enums;
 
 public class AttackComponent : MonoBehaviour, IAttacker
 {
-    private CharacterCore _characterCore;
+    private ICharacterStatus _status;
 
     private float _attackCooldownDuration; // 쿨다운 시간
     private float _nextAttackTime = 0f;
@@ -15,15 +15,15 @@ public class AttackComponent : MonoBehaviour, IAttacker
     public event Action<IDamageable> OnAttackHit;
 
     // CharacterCore로부터 초기 스탯을 받아 초기화하는 메서드
-    public void Initialize(CharacterCore characterCore)
+    public void Initialize(ICharacterCore characterCore)
     {
         if (characterCore == null) return;
-        _characterCore = characterCore;
+        _status = characterCore.CharacterStatus;
 
-        _attackCooldownDuration = 1f / _characterCore.Status.AttackSpeed;
+        _attackCooldownDuration = 1f / _status.AttackSpeed;
         
 #if UNITY_EDITOR
-        Debug.Log($"AttackComponent Initialized: Damage={_characterCore.Status.AttackDamage}, Cooldown={_attackCooldownDuration:F2}s");
+        Debug.Log($"AttackComponent Initialized: Damage={_status.AttackDamage}, Cooldown={_attackCooldownDuration:F2}s");
 #endif
     }
 
@@ -49,7 +49,7 @@ public class AttackComponent : MonoBehaviour, IAttacker
 
     private void PerformDamageApplication()
     {
-        Collider[] hitColliders = Physics.OverlapSphere(transform.position, _characterCore.Status.AttackRange);
+        Collider[] hitColliders = Physics.OverlapSphere(transform.position, _status.AttackRange);
         foreach (Collider hitCollider in hitColliders)
         {
             IDamageable damageableTarget = hitCollider.GetComponent<IDamageable>();
@@ -57,13 +57,13 @@ public class AttackComponent : MonoBehaviour, IAttacker
 
             if (damageableTarget != null && targetCore != null && targetCore.gameObject != this.gameObject)
             {
-                if (_characterCore.Status.Faction != targetCore.Data.Faction) // 진영이 다를 때만 공격
+                if (_status.Faction != targetCore.Data.Faction) // 진영이 다를 때만 공격
                 {
                     /* 스킬 수행 예정 */
 #if UNITY_EDITOR
                     Debug.Log($"{gameObject.GetComponent<CharacterCore>().Data.CharacterName}:{gameObject.GetInstanceID()}이 {targetCore.Data.CharacterName}:{targetCore.GetInstanceID()}을 공격");
                     /* 테스트 용 코드 */
-                    damageableTarget.TakeDamage(_characterCore.Status.AttackDamage, DamageType.Pyhsical);
+                    damageableTarget.TakeDamage(_status.AttackDamage, DamageType.Pyhsical);
 #endif
                 }
             }


### PR DESCRIPTION
- 이전 CharacterCore 인터페이스화 리팩토링 커밋에서 누락되었던 `AttackComponent`에 `ICharacterCore` 의존성 적용.
    - `AttackComponent`가 `CharacterCore` 구현체 대신 `ICharacterCore` 인터페이스를 통해 접근하도록 수정.