### PR TITLE
feat : Scene-Logic

### DIFF
--- a/Assets/00.Core/Enums/Enums.cs
+++ b/Assets/00.Core/Enums/Enums.cs
@@ -89,9 +89,10 @@ namespace ProjectD_and_R.Enums
     public enum GameState
     {
         MainMenu,
-        StageStarting,
-        StageInProgress,
-        StagePaused,
+        Loading,
+        SceneStarting,
+        SceneInProgress,
+        ScenePaused,
         StageEnded,
         GameOver
     }
@@ -101,6 +102,8 @@ namespace ProjectD_and_R.Enums
         None,
         DefenseTurn,
         DungeonTurn,
+        DungeonBattleTurn,
+        VillageTurn,
     }
 
     public enum CharacterRarity

--- a/Assets/00.Core/StringConstants.meta
+++ b/Assets/00.Core/StringConstants.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a9d8fd4c4b814c498f6e69f26ffd7fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00.Core/StringConstants/StringConstants.cs
+++ b/Assets/00.Core/StringConstants/StringConstants.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace ProjectD_and_R.Constants
+{
+    public class StringConstants : MonoBehaviour
+    {
+        public static readonly string TitleScene = "00.Title";
+        public static readonly string LoadingScene = "01.Loding";
+        public static readonly string DefenseScene = "02.DefenseTurn";
+        public static readonly string VillageScene = "03.Village";
+        public static readonly string DungeonScene = "04.Dungeon";
+        public static readonly string DungeonBattleScene = "05.DungeonBattle";
+    }
+}
+
+

--- a/Assets/00.Core/StringConstants/StringConstants.cs.meta
+++ b/Assets/00.Core/StringConstants/StringConstants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d24f25a2437a6045b9f9e37ffebef98

--- a/Assets/02.Scripts/Manager/GameManager.cs
+++ b/Assets/02.Scripts/Manager/GameManager.cs
@@ -10,7 +10,7 @@ public class GameManager : Singleton<GameManager>
     private GameState _currentGameState = GameState.MainMenu;
     [SerializeField][Header("현재 씬 이름")] string CurrentScene = "Title";
 
-    [SerializeField][Header("데이터 로더들")]public LoaderContainer LoaderContainer;
+    [SerializeField][Header("데이터 로더들")] public LoaderContainer LoaderContainer;
 
     public SceneArriveEvent sceneArriveEvent;
     public GameState CurrentGameState
@@ -58,9 +58,6 @@ public class GameManager : Singleton<GameManager>
         base.Awake();
         LoaderContainer = new LoaderContainer();
         sceneArriveEvent = new SceneArriveEvent();
-        //ObjectPoolManager.Instance.Initialize(this.gameObject.transform);
-        //ObjectPoolManager.Instance.PreloadPrefab("Assets/03.Prefabs/Characters/TestEnemy.prefab", 1);
-        //StartCoroutine(Test_GameStart());
     }
 
     // 특정 스테이지 시작 요청
@@ -69,16 +66,16 @@ public class GameManager : Singleton<GameManager>
         if (CurrentGameState != GameState.MainMenu && CurrentGameState != GameState.StageEnded)
             return;
 
-        CurrentGameState = GameState.StageStarting; // 스테이지 시작 중 상태로 변경
-        CurrentGameState = GameState.StageInProgress;
+        CurrentGameState = GameState.SceneStarting; // 스테이지 시작 중 상태로 변경
+        CurrentGameState = GameState.SceneInProgress;
     }
 
     // 게임 일시 중지
     public void PauseGame()
     {
-        if (CurrentGameState == GameState.StageInProgress)
+        if (CurrentGameState == GameState.SceneInProgress)
         {
-            CurrentGameState = GameState.StagePaused;
+            CurrentGameState = GameState.ScenePaused;
             Time.timeScale = 0f; // 게임 시간 정지 (유니티 전역)
         }
     }
@@ -86,9 +83,9 @@ public class GameManager : Singleton<GameManager>
     // 게임 재개
     public void ResumeGame()
     {
-        if (CurrentGameState == GameState.StagePaused)
+        if (CurrentGameState == GameState.ScenePaused)
         {
-            CurrentGameState = GameState.StageInProgress;
+            CurrentGameState = GameState.SceneInProgress;
             Time.timeScale = 1f; // 게임 시간 재개
         }
     }
@@ -96,7 +93,7 @@ public class GameManager : Singleton<GameManager>
     // 스테이지 종료 (성공 또는 실패)
     public void EndStage()
     {
-        if (CurrentGameState == GameState.StageInProgress || CurrentGameState == GameState.StagePaused)
+        if (CurrentGameState == GameState.SceneInProgress || CurrentGameState == GameState.ScenePaused)
         {
             CurrentGameState = GameState.StageEnded;
             Time.timeScale = 1f; // 혹시 중지 상태였다면 재개
@@ -132,9 +129,22 @@ public class GameManager : Singleton<GameManager>
     {
         CurrentScene = scene.name;
         sceneArriveEvent.SceneEvent(CurrentScene);
+
+        OnGameStateChanged?.Invoke(CurrentGameState);
+        OnTurnStateChanged?.Invoke(CurrentTurnState);
     }
     void OnDisable()
     {
         SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    public void SetGameState(GameState newState)
+    {
+        CurrentGameState = newState;
+    }
+
+    public void SetTurnState(ProjectD_and_R.Enums.TurnState newState)
+    {
+        CurrentTurnState = newState;
     }
 }

--- a/Assets/02.Scripts/Scene/SceneArriveEvent.cs
+++ b/Assets/02.Scripts/Scene/SceneArriveEvent.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using UnityEngine;
+using ProjectD_and_R.Constants;
+using ProjectD_and_R.Enums;
 
 public class SceneArriveEvent
 {
@@ -10,7 +12,7 @@ public class SceneArriveEvent
             RpgManager.Instance.RoomEnterSystem.battleEnter.SetBattle(EnemyType.Spider);
         }
         else if (sceneName == "RandomMapGenerator")
-        {        
+        {
             GameObject parent = GameObject.Find(RpgManager.Instance.MapParent).gameObject;
             ZoneLayoutSystem zoneLayoutSystem = RpgManager.Instance.zoneLayoutSystem;
 
@@ -21,10 +23,39 @@ public class SceneArriveEvent
             else
             {
                 MapBlueprint newBlueprint = zoneLayoutSystem.GenerateNewMap(RpgManager.Instance.roomPrefab, parent);
-                RpgManager.Instance.mapBlueprint = newBlueprint; 
+                RpgManager.Instance.mapBlueprint = newBlueprint;
             }
 
             if (RpgManager.Instance.CheckEndOfRPG()) RpgManager.Instance.EndRPG();
+        }
+
+        if (sceneName == StringConstants.TitleScene)
+        {
+            GameManager.Instance.SetGameState(GameState.MainMenu);
+        }
+        else if (sceneName == StringConstants.LoadingScene)
+        {
+            GameManager.Instance.SetGameState(GameState.Loading);
+        }
+        else if (sceneName == StringConstants.VillageScene)
+        {
+            GameManager.Instance.SetGameState(GameState.SceneStarting);
+            GameManager.Instance.SetTurnState(ProjectD_and_R.Enums.TurnState.VillageTurn);
+        }
+        else if (sceneName == StringConstants.DefenseScene)
+        {
+            GameManager.Instance.SetGameState(GameState.SceneStarting);
+            GameManager.Instance.SetTurnState(ProjectD_and_R.Enums.TurnState.DefenseTurn);
+        }
+        else if (sceneName == StringConstants.DungeonScene)
+        {
+            GameManager.Instance.SetGameState(GameState.SceneStarting);
+            GameManager.Instance.SetTurnState(ProjectD_and_R.Enums.TurnState.DungeonTurn);
+        }
+        else if (sceneName == StringConstants.DungeonBattleScene)
+        {
+            GameManager.Instance.SetGameState(GameState.SceneStarting);
+            GameManager.Instance.SetTurnState(ProjectD_and_R.Enums.TurnState.DungeonBattleTurn);
         }
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,29 +6,23 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/01.Scenes/Title.unity
+    path: Assets/01.Scenes/00.Title.unity
     guid: ce54c7242eb2f2842b5004ddfbca4085
   - enabled: 1
-    path: Assets/01.Scenes/DungeonBattle.unity
-    guid: 2dcf5ee2cd42c2d4d91c18de8cd53772
-  - enabled: 1
-    path: Assets/01.Scenes/DungeonCrawling.unity
-    guid: 7897f2c3308483c4a8204fbcba131e38
-  - enabled: 1
-    path: Assets/01.Scenes/RandomMapGenerator.unity
-    guid: ece8779dedf33e645b68527f6ed792ef
-  - enabled: 1
-    path: Assets/01.Scenes/RpgOtherQuarters.unity
-    guid: ccd291c9b0974cc4aa4175e21fdda897
-  - enabled: 1
-    path: Assets/01.Scenes/SampleScene.unity
-    guid: 9fc0d4010bbf28b4594072e72b8655ab
-  - enabled: 1
-    path: Assets/01.Scenes/UnitTestScene.unity
-    guid: b256eb1b123d73847b33ea03d9a90f1f
-  - enabled: 1
-    path: Assets/01.Scenes/Loding.unity
+    path: Assets/01.Scenes/01.Loding.unity
     guid: 0e15378e0fbf6e64f9c9963c8cee65b3
+  - enabled: 1
+    path: Assets/01.Scenes/02.DefenseTurn.unity
+    guid: 43911b8b5cdedae46962f7cbaaf4cd17
+  - enabled: 1
+    path: Assets/01.Scenes/03.Village.unity
+    guid: 46ebe15d8f2e61b489268d56d9a0a8de
+  - enabled: 1
+    path: Assets/01.Scenes/04.Dungeon.unity
+    guid: 24093e441c199394985d18fd2d25e9c7
+  - enabled: 1
+    path: Assets/01.Scenes/05.DungeonBattle.unity
+    guid: 2dcf5ee2cd42c2d4d91c18de8cd53772
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: a1fe6b1f8d9d2b14ba8abce05b0ac31e, type: 2}
     com.unity.dt.app-ui: {fileID: 11400000, guid: 99f9c9493070a9d4c979a8fec7c5a8d3, type: 2}


### PR DESCRIPTION
- Scene 구분을 위한 static readonly String변수 관리할 'StringConstants.cs' 추가
- 'Enums.cs' TurnState에 VillageTurn, DungeonBattleTurn 추가
- 'Enum.cs' GameState에 Loading추가, 기존 Stage ~~을 -> Scene ~~ 으로 변경
- 'SceneArriveEvent.cs' Turn별 수행 로직 추가
- EditorBuildSettings SceneList변경. '00.Title', '01.Loading', '02.DefenseTurn', '03.Village', '04.Dungeon', '05.DungeonBattle'